### PR TITLE
Add disallow rule for Google-Extended in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -6,3 +6,6 @@ Disallow: /
 
 User-agent: CCBot
 Disallow: /
+
+User-agent: Google-Extended
+Disallow: /


### PR DESCRIPTION
https://searchengineland.com/google-extended-crawler-432636
https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers